### PR TITLE
fix: 商品編集確認画面からリダイレクトしてもViewで表示できなかったため、リダイレクト先の調整を追加

### DIFF
--- a/src/main/java/com/example/demo/controllers/RootController.java
+++ b/src/main/java/com/example/demo/controllers/RootController.java
@@ -1,5 +1,5 @@
 package com.example.demo.controllers;
-
+import java.net.URI;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import com.example.demo.models.ItemForm;
 import com.example.demo.repositries.ItemRepository;
@@ -87,34 +88,31 @@ public class RootController {
         return "item/confirm-update";
     }
     
-    //ここから続き。
-	@PostMapping("/update-result")
-	public String updateExecuteAndResult(@Validated ItemForm itemForm, BindingResult bindingResult, Model model) {
-		if (bindingResult.hasErrors()) { //バリデーションエラーが発生した場合の処理
-			return "redirect:/create";
-		}
-		// RDBと連携できることを確認しておきます。
-		//バリデーションが成功した場合の処理
+    //商品編集確認画面で更新ボタンをクリック
+	@PostMapping("/confirm-update")
+	public String updateExecuteAndResult(ItemForm itemForm, Model model) {	
 		repository.saveAndFlush(itemForm);//このメソッドはitemRepositoyの継承元のJpaRepository（のもっと親）にあるメソッド。
 		itemForm.clear();
-		model.addAttribute("message", "登録が完了しました。");
-		return "redirect:/create";
+		model.addAttribute("message", "更新が完了しました。");
+		
+		//redirectするとデフォルトでhttpになってしまうためhttpsを指定してる
+	    UriComponentsBuilder builder = UriComponentsBuilder.newInstance();
+	    URI location = builder.scheme("https").host("127.0.0.1").path("/list").build().toUri();
+	    return "redirect:" + location.toString();
 	}
 
+    
     @GetMapping("/delete/{id}")
     public String confirmDelete(@PathVariable("id") Long id, Model model) {
         ItemForm item = repository.findById(id).orElse(null);
         model.addAttribute("itemForm", item);
-        model.addAttribute("message", "id " + id + " のレコードの削除がクリックされましたよ");
-        return "item/delete";
+        return "item/confirm-delete";
     }
 
-    @PostMapping("/delete")
+    @PostMapping("/confirm-delete")
     public String deleteConfirmed(@ModelAttribute ItemForm itemForm, Model model) {
         repository.deleteById(itemForm.getId());
         model.addAttribute("message", "商品ID " + itemForm.getId() + " のレコードが削除されました");
         return "redirect:/delete";
     }
-	
-	
 }

--- a/src/main/java/com/example/demo/models/ItemForm.java
+++ b/src/main/java/com/example/demo/models/ItemForm.java
@@ -12,7 +12,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
-
 import lombok.Data;
 
 //今回のitemForm.javaはフォームであり、エンティティである。

--- a/src/main/resources/templates/item/confirm-delete.html
+++ b/src/main/resources/templates/item/confirm-delete.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>ポートフォリオサイト</title>
+<title>商品削除確認</title>
 <link rel="stylesheet" media="all" th:href="@{/css/ress.min.css}" />
 <link rel="stylesheet" media="all" th:href="@{/css/style.css}" />
 <script th:src="@{/js/jquery-2.1.4.min.js}"></script>
@@ -11,6 +11,7 @@
 
 <!-- Favicon -->
 <link rel="icon" type="image/png" th:href="@{/img/favicon.png}">
+
 </head>
 <body>
 	<header>
@@ -55,36 +56,27 @@
 					<div class="col span-12">
 						<div class="breadcrumb">
 							<ul>
-								<li><a th:href="@{/demo}">ホーム</a> > 商品一覧</li>
+								<li><a th:href="@{/demo}">ホーム</a> > 商品削除確認</li>
 							</ul>
 						</div>
 
-
-
-						<h2 class="underline">商品一覧</h2>
-						<th:block th:if="message != null">
-							<h2 th:class="msg" th:text="${message}"></h2>
-						</th:block>
-						<table>
-						    <tr>
-								<th>ID</th>
-						        <th>商品名</th>
-						        <th>価格</th>
-						        <th>説明</th>
-						        <th></th>
-						        <th></th>
-						    </tr>
-							<div th:each="item : ${items}">
-							    <tr>
-							        <td th:text="${item.id}"></td>
-							        <td th:text="${item.name}"></td>
-							        <td th:text="${item.price}"></td>
-							        <td th:text="${item.description}"></td>
-									<td><a th:href="@{'/update/' + ${item.id}}">編集</a></td>
-									<td><a th:href="@{'/delete/' + ${item.id}}">削除</a></td>
-							    </tr>
-							</div>
-						</table>
+						<h2 class="underline">商品削除</h2>
+						<form th:action="@{/confirm-delete}" th:object="${itemForm}" method="post">
+							<p>この商品を削除しますか？</p>
+                            <p>商品ID: <span th:text="${itemForm.id}"></span></p>
+                            <p>商品名: <span th:text="${itemForm.name}"></span></p>
+                            <p>価格: <span th:text="${itemForm.price}"></span></p>
+                            <p>説明: <span th:text="${itemForm.description}"></span></p>
+							
+							<!-- 隠しフィールドでデータを送信 -->
+							<input type="hidden" th:field="*{id}" />
+							<input type="hidden" th:field="*{name}" />
+							<input type="hidden" th:field="*{price}" />
+							<input type="hidden" th:field="*{description}" />
+							<p>
+								<input class="button" type="submit" value="削除">
+							</p>
+						</form>
 					</div>
 				</div>
 			</div>

--- a/src/main/resources/templates/item/confirm-update.html
+++ b/src/main/resources/templates/item/confirm-update.html
@@ -61,13 +61,18 @@
 						</div>
 
 						<h2 class="underline">商品編集</h2>
-						<form th:action="@{/update-result}" th:object="${itemForm}" method="post">
+						<form th:action="@{/confirm-update}" th:object="${itemForm}" method="post">
 							<p>商品を以下の内容で更新しますか？</p>
                             <p>商品ID: <span th:text="${itemForm.id}"></span></p>
                             <p>商品名: <span th:text="${itemForm.name}"></span></p>
                             <p>価格: <span th:text="${itemForm.price}"></span></p>
                             <p>説明: <span th:text="${itemForm.description}"></span></p>
-                           <!-- <input type="hidden" th:field="*{id}" />-->
+							
+							<!-- 隠しフィールドでデータを送信 -->
+							<input type="hidden" th:field="*{id}" />
+							<input type="hidden" th:field="*{name}" />
+							<input type="hidden" th:field="*{price}" />
+							<input type="hidden" th:field="*{description}" />
 							<p>
 								<input class="button" type="submit" value="更新">
 							</p>


### PR DESCRIPTION
商品編集確認画面で更新ボタンを押下時にリダイレクト先がhttpsからhttpに自動変更されてしまいViewが表示されなかったため、UriComponentsBuilderを使ってリダイレクト先のURLをhttpsに戻す処理を追加。