### PR TITLE
fix:商品一覧画面の表示崩れ

### DIFF
--- a/src/main/java/com/example/demo/controllers/RootController.java
+++ b/src/main/java/com/example/demo/controllers/RootController.java
@@ -1,7 +1,6 @@
 package com.example.demo.controllers;
 import java.net.URI;
 import java.util.List;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;

--- a/src/main/java/com/example/demo/forms/ItemForm.java
+++ b/src/main/java/com/example/demo/forms/ItemForm.java
@@ -26,7 +26,7 @@ public class ItemForm implements Serializable {
 
 	//ここからはフォームクラス。
 	@NotBlank(message = "商品名を入力してください。")
-	@Size(max = 20,message = "商品名は20文字以下で入力してください。")
+	@Size(max = 10,message = "商品名は20文字以下で入力してください。")
 	private String name;
 
 	@NotNull(message = "価格を入力してください。")
@@ -34,7 +34,7 @@ public class ItemForm implements Serializable {
 	private Integer price;
 
 	@NotBlank(message = "商品説明を入力してください。")
-	@Size(max = 300,message = "商品説明は300文字以下で入力してください。")
+	@Size(max = 180,message = "商品説明は180文字以下で入力してください。")
 	private String description;
 
 	public void clear() {

--- a/src/main/java/com/example/demo/services/ItemService.java
+++ b/src/main/java/com/example/demo/services/ItemService.java
@@ -32,6 +32,4 @@ public class ItemService {
 	public void seveDelete(ItemForm itemForm) {
 		repository.deleteById(itemForm.getId());
 	}
-
-
 }

--- a/src/main/resources/templates/item/list.html
+++ b/src/main/resources/templates/item/list.html
@@ -77,11 +77,11 @@
 							<div th:each="item : ${items}">
 							    <tr>
 							        <td th:text="${item.id}"></td>
-							        <td th:text="${item.name}"></td>
+							        <td class="list-item-name" th:text="${item.name}"></td>
 							        <td th:text="${item.price}"></td>
-							        <td th:text="${item.description}"></td>
-									<td><a th:href="@{'/update/' + ${item.id}}">編集</a></td>
-									<td><a th:href="@{'/delete/' + ${item.id}}">削除</a></td>
+							        <td class="list-item-descriprion" th:text="${item.description}"></td>
+									<td><a class="table-actions" th:href="@{'/update/' + ${item.id}}">編集</a></td>
+									<td><a class="table-actions" th:href="@{'/delete/' + ${item.id}}">削除</a></td>
 							    </tr>
 							</div>
 						</table>


### PR DESCRIPTION
商品一覧画面で商品説明の文字数が多くなると削除と編集ボタンが縦書きになる表示崩れを修正。